### PR TITLE
增加新主题和验证码绕过功能

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,12 +27,17 @@ docker run -itd \
  --name PanIndex \
  -d -p 8080:8080 \
  -v /home/single/data/docker/data/PanIndex/data:/app/data \
+ -e HOST="0.0.0.0" \
  -e CLOUD_USER="1860****837" \
  -e CLOUD_PASSWORD="1234" \
  -e ROOT_ID="-11" \
  -e PWD_DIR_ID="51496311321353335:1234" \
  -e HIDE_FILE_ID="" \
  -e HEROKU_APP_URL="" \
+ -e API_TOKEN="" \
+ -e THEME="bootstrap" \
+ -e DMG_USER="" \
+ -e DMG_PASS="" \
  iicm/pan-index
 ```
 ## 程序包独立部署（vps）
@@ -50,6 +55,12 @@ $ ./PanIndex -config.path=config.json
 ## 接口
 - 手动刷新目录缓存：`GET /api/updateFolderCache?token=<ApiToken>`
 
+## 验证码识别
+由于天翼云盘登录会有一定几率触发验证码，因此可以利用第三方验证码识别平台进行识别。
+
+目前暂时使用的平台为打码狗 [damagou.top](http://www.damagou.top)，该平台需付费使用。
+
+本功能默认关闭，如需启用只需在配置文件中填写平台用户名密码即可。
 
 **配置文件说明:**
 
@@ -65,6 +76,8 @@ $ ./PanIndex -config.path=config.json
 |  hide_file_id |  0 | 否 |  隐藏目录id ，多个文件`,`分隔 | 213123,23445  |
 |  heroku_app_url |  0 | 否 | 部署后的herokuapp网盘地址，heroku部署必须 | https://app-name.herokuapp.com  |
 |  api_token |  0 | 否 | 调用私有api的秘钥 | 1234  |
+|  theme | 0 | 是 | 使用的主题，目前支持 classic, bootstrap, materialdesign | bootstrap |
+|  damagou | 1 | 否 | 打码狗平台的用户名和密码，用于识别验证码 | username,password |
 
 config.json
 ```json
@@ -81,6 +94,12 @@ config.json
     ],
     "hide_file_id": "",
     "heroku_app_url":"https://pan-index.herokuapp.com",
-    "api_token": "1234"
+    "api_token": "1234",
+    "theme": "bootstrap",
+    "damagou": {
+        "username":"",
+        "password":""
+    }
 }
 ```
+

--- a/README.md
+++ b/README.md
@@ -64,24 +64,26 @@ $ ./PanIndex -config.path=config.json
 
 **配置文件说明:**
 
-|  字段名 |  层级  | 必填  | 描述  | 示例  |
-| :------------: | :------------:| :------------: | :------------: | :------------: |
-|  port | 0  | 是 | 端口  | 8080  |
-|  user | 0  | 是 | 天翼云账号，一般是手机号  | 183xxxx7765  |
-|  password | 0  | 是 |  天翼云账号密码 |  1234 |
-|  root_id |  0 | 是 | 网盘根目录ID  |  -11，代表天翼云顶层目录 |
-| pwd_dir_id  | 0  | 否 | 加密文件目录id和密码  | 数组  |
-| id  | 1  | 否 |  加密目录id |  5149xxx1353335 |
-|  pwd |  1 | 否 |  加密目录访问密码 | 1234  |
-|  hide_file_id |  0 | 否 |  隐藏目录id ，多个文件`,`分隔 | 213123,23445  |
-|  heroku_app_url |  0 | 否 | 部署后的herokuapp网盘地址，heroku部署必须 | https://app-name.herokuapp.com  |
-|  api_token |  0 | 否 | 调用私有api的秘钥 | 1234  |
-|  theme | 0 | 是 | 使用的主题，目前支持 classic, bootstrap, materialdesign | bootstrap |
-|  damagou | 1 | 否 | 打码狗平台的用户名和密码，用于识别验证码 | username,password |
+|  字段名         | 层级  | 必填  | 描述                                                    | 示例                           |
+| :-------------: | :----:| :---: | :-----------------------------------------------------: | :----------------------------: |
+|  host           | 0     | 否    | 服务监听地址                                            | 0.0.0.0                        |
+|  port           | 0     | 是    | 端口                                                    | 8080                           |
+|  user           | 0     | 是    | 天翼云账号，一般是手机号                                | 183xxxx7765                    |
+|  password       | 0     | 是    | 天翼云账号密码                                          | 1234                           |
+|  root_id        | 0     | 是    | 网盘根目录ID                                            | -11，代表天翼云顶层目录        |
+|  pwd_dir_id     | 0     | 否    | 加密文件目录id和密码                                    | 数组                           |
+|  id             | 1     | 否    | 加密目录id                                              | 5149xxx1353335                 |
+|  pwd            | 1     | 否    | 加密目录访问密码                                        | 1234                           |
+|  hide_file_id   | 0     | 否    | 隐藏目录id ，多个文件`,`分隔                            | 213123,23445                   |
+|  heroku_app_url | 0     | 否    | 部署后的herokuapp网盘地址，heroku部署必须               | https://app-name.herokuapp.com |
+|  api_token      | 0     | 否    | 调用私有api的秘钥                                       | 1234                           |
+|  theme          | 0     | 是    | 使用的主题，目前支持 classic, bootstrap, materialdesign | bootstrap                      |
+|  damagou        | 1     | 否    | 打码狗平台的用户名和密码，用于识别验证码                | username,password              |
 
 config.json
 ```json
 {
+    "host": "0.0.0.0",
     "port": 8080,
     "user": "183xxxx7765",
     "password": "xxxx",

--- a/config/config.go
+++ b/config/config.go
@@ -22,6 +22,7 @@ func LoadCloud189Config(path string) {
 		log.Fatal("PathExists(%s),err(%v)\n", path, err)
 	}
 	config := os.Getenv("CONFIG")
+	host := os.Getenv("HOST")
 	port := os.Getenv("PORT")
 	user := os.Getenv("CLOUD_USER")
 	pwd := os.Getenv("CLOUD_PASSWORD")
@@ -30,6 +31,9 @@ func LoadCloud189Config(path string) {
 	hfi := os.Getenv("HIDE_FILE_ID")
 	hau := os.Getenv("HEROKU_APP_URL")
 	apitk := os.Getenv("API_TOKEN")
+	theme := os.Getenv("THEME")
+	dmg_usr := os.Getenv("DMG_USER")
+	dmg_pwd := os.Getenv("DMG_PASS")
 	if b {
 		file, err := os.Open(path)
 		if err != nil {
@@ -42,6 +46,9 @@ func LoadCloud189Config(path string) {
 	err = jsoniter.Unmarshal([]byte(config), &Config189)
 	if err != nil {
 		log.Println("配置文件读取失败，从环境变量读取配置")
+	}
+	if host != "" {
+		Config189.Host = host
 	}
 	if port != "" {
 		portInt, _ := strconv.Atoi(port)
@@ -76,6 +83,15 @@ func LoadCloud189Config(path string) {
 	if apitk != "" {
 		Config189.ApiToken = apitk
 	}
+	if theme != "" {
+		Config189.Theme = theme
+	}
+	if dmg_usr != "" {
+		Config189.Damagou.Username = dmg_usr
+	}
+	if dmg_pwd != "" {
+		Config189.Damagou.Password = dmg_pwd
+	}
 }
 func PathExists(path string) (bool, error) {
 	_, err := os.Stat(path)
@@ -89,6 +105,7 @@ func PathExists(path string) (bool, error) {
 }
 
 type Cloud189Config struct {
+	Host         string     `json:"host"`
 	Port         int        `json:"port"`
 	User         string     `json:"user"`
 	Password     string     `json:"password"`
@@ -97,9 +114,16 @@ type Cloud189Config struct {
 	HideFileId   string     `json:"hide_file_id"`
 	HerokuAppUrl string     `json:"heroku_app_url"`
 	ApiToken     string     `json:"api_token"`
+	Theme        string     `json:"theme"`
+	Damagou      Damagou    `json:"damagou"`
 }
 
 type PwdDirId struct {
 	Id  string `json:"id"`
 	Pwd string `json:"pwd"`
+}
+
+type Damagou struct {
+	Username string `json:"username"`
+	Password string `json:"password"`
 }

--- a/config/config.json
+++ b/config/config.json
@@ -1,4 +1,5 @@
 {
+  "host": "0.0.0.0",
   "port": 8080,
   "user": "",
   "password": "xxxx",
@@ -11,5 +12,10 @@
   ],
   "hide_file_id": "",
   "heroku_app_url":"",
-  "api_token": ""
+  "api_token": "",
+  "theme": "bootstrap",
+  "damagou": {
+	"username":"",
+	"password":""
+  }
 }

--- a/jobs/Jobs.go
+++ b/jobs/Jobs.go
@@ -35,11 +35,7 @@ func Run() {
 	})
 	c.Start()
 }
-func StartInit(path string) {
-	config.LoadCloud189Config(path)
-	if config.Config189.User != "" {
-		log.Println("[程序启动]配置加载 >> 获取成功")
-	}
+func StartInit() {
 	cookie := Util.Cloud189Login(config.Config189.User, config.Config189.Password)
 	if cookie != "" {
 		log.Println("[程序启动]cookie更新 >> 登录成功")

--- a/templates/189/bootstrap/index.html
+++ b/templates/189/bootstrap/index.html
@@ -1,0 +1,121 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<title>Index of {{ .Path }}</title>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, initial-scale=1.0">
+		<link rel="icon" href="/static/img/favicon.ico" type="image/x-icon" />
+		<link rel="shortcut icon" href="/static/img/favicon.ico" type="image/x-icon" />
+		<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css">
+		<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/font-awesome@4.7.0/css/font-awesome.css">
+		<style type="text/css">
+		body {
+			/*background: #F5F5F5;*/
+			font-weight: 100;
+			font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+		}
+		#heading {
+			padding: 16px 0px 16px 0px;
+			font-weight: 400;
+		}
+		.file-name a {
+			color: #000000;
+		}
+		.fa {
+			width: 16px;
+		}
+		.fa-file {
+			color: #AAAAAA;
+		}
+		.fa-folder {
+			color: rgb(255 211 66);
+		}
+		.icon-dir, .icon-file, .icon-up {
+			display: inline-block;
+			width: 100%;
+			text-decoration: none ! important;
+		}
+		.table-head, .table thead th {
+			font-weight: 500;
+		}
+		</style>
+	</head>
+	<body>
+		{{if .HasPwd}}
+		<script>
+			promptPwd("{{ .FileId}}");
+			function promptPwd(fileId){
+				var pwd = prompt("这是一个受保护的文件夹，您需要提供访问密码才能查看。");
+				$.cookie("dir_pwd", pwd);
+				location.reload();
+			}
+		</script>
+		{{else}}
+		<div class="container">
+			<div class="row">
+				<div class="col-sm-12">
+					<h2 id="heading">Index of {{ .Path }}</h2>
+				</div>
+			</div>
+			<div class="row">
+				<div class="col-sm-12 table-responsive">
+					<table class="table table-striped table-hover">
+						<thead>
+						<tr>
+							<th class="file-name"><span class="table-head" data-order-seq="" data-order-type="file-name" style="cursor: default;">Name</span></th>
+							<th class="file-size"><span class="table-head" data-order-seq="" data-order-type="file-size" style="cursor: default;">Size</span></th>
+							<th class="file-date-modified"><span class="table-head" data-order-seq="" data-order-type="file-date-modified" style="cursor: default;">Date Modified</span></th></th>
+							<th class="text-center">Download</th>
+						</tr>
+						</thead>
+						<tbody>
+							{{if .HasParent}}
+								<tr class="parent">
+									<td class="file-name">
+										<a class="icon icon-up" href="{{.ParentPath}}"><i class="fa fa-chevron-left" aria-hidden="true"></i>&nbsp;&nbsp;..</a>
+									</td>
+									<td class="file-size"></td>
+									<td class="file-date-modified"></td>
+									<td class="file-size"></td>
+								</tr>
+							{{else}}
+							{{end}}
+							{{range .List}}
+								<tr>
+									{{if .IsFolder}}
+										<td class="file-name"><a class="icon icon-dir" href="{{.Path}}"><i class="fa fa-folder" aria-hidden="true"></i>&nbsp;&nbsp;{{.FileName}}</a></td>
+									{{else}}
+										<td class="file-name"><a class="icon icon-file"data-file-type="{{.FileType}}" data-media-type="{{.MediaType}}" data-title="{{.FileName}}" data-url="{{.Path}}" href="javascript:void(0);"><i class="fa fa-file" aria-hidden="true"></i>&nbsp;&nbsp;{{.FileName}}</a></td>
+									{{end}}
+									<td class="file-size">{{.SizeFmt}}</td>
+									<td class="file-date-modified">{{.LastOpTime}}</td>
+									{{if .IsFolder}}
+										{{if and (ne .FileId "0") (ne .FileId "-12") (ne .FileId "-14") (ne .FileId "-13") (ne .FileId "-15") (ne .FileId "-11") (ne .FileId "-16")}}
+											<td class="text-center"><a class="folderDown" data-file-id="{{.FileId}}" href="javascript:void(0);" target="_blank" ><i class="fa fa-download" aria-hidden="true"></i></a></td>
+										{{else}}
+											<td class="file-size">-</td>
+										{{end}}
+									{{else}}
+										<td class="text-center"><a href="{{.Path}}" target="_blank"><i class="fa fa-download" aria-hidden="true"></i></a></td>
+									{{end}}
+								</tr>
+							{{end}}
+						</tbody>
+					</table>
+				</div>
+				<div class="col-sm-12">
+					<div class="text-center">
+						<span>Powered by <a href="https://github.com/libsgh/PanIndex" target="_blank">PanIndex</a> | Themes by <a href="https://github.com/kasuganosoras">Akkariin</a></span>
+					</div>
+				</div>
+			</div>
+		</div>
+		{{end}}
+		<div id="example1"></div>
+	</body>
+	<script>var HerokuappUrl = {{.HerokuappUrl}}</script>
+	<script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"></script>
+	<script src="https://cdn.jsdelivr.net/npm/jquery@3.5.1/dist/jquery.min.js"></script>
+	<script src="https://cdn.bootcdn.net/ajax/libs/jquery-cookie/1.0/jquery.cookie.min.js"></script>
+	<script src="/static/js/main189.js"></script>
+</html>

--- a/templates/189/materialdesign/index.html
+++ b/templates/189/materialdesign/index.html
@@ -1,0 +1,126 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<title>Index of {{ .Path }}</title>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, initial-scale=1.0">
+		<link rel="icon" href="/static/img/favicon.ico" type="image/x-icon" />
+		<link rel="shortcut icon" href="/static/img/favicon.ico" type="image/x-icon" />
+		<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/0.97.8/css/materialize.min.css">
+		<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/font-awesome@4.7.0/css/font-awesome.css">
+		<style type="text/css">
+		body {
+			/*background: #F5F5F5;*/
+			font-weight: 100;
+			font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+		}
+		#heading {
+			/*padding: 16px 0px 16px 0px;*/
+			font-weight: 400;
+		}
+		.file-name a {
+			color: #000000;
+		}
+		.fa {
+			width: 16px;
+		}
+		.fa-file {
+			color: #AAAAAA;
+		}
+		.fa-folder {
+			color: rgb(255 211 66);
+		}
+		.icon-dir, .icon-file, .icon-up {
+			display: inline-block;
+			width: 100%;
+			margin-left: 16px;
+			text-decoration: none ! important;
+		}
+		.table-head, .table thead th {
+			font-weight: 500;
+		}
+		.footer {
+			margin-top: 32px;
+			margin-bottom: 32px;
+		}
+		</style>
+	</head>
+	<body>
+		{{if .HasPwd}}
+		<script>
+			promptPwd("{{ .FileId}}");
+			function promptPwd(fileId){
+				var pwd = prompt("这是一个受保护的文件夹，您需要提供访问密码才能查看。");
+				$.cookie("dir_pwd", pwd);
+				location.reload();
+			}
+		</script>
+		{{else}}
+		<div class="container">
+			<div class="row">
+				<div class="col s12">
+					<h2 id="heading">Index of {{ .Path }}</h2>
+				</div>
+			</div>
+			<div class="row">
+				<div class="col s12">
+					<table class="table striped highlight responsive-table">
+						<thead>
+						<tr>
+							<th class="file-name"><span class="table-head" data-order-seq="" data-order-type="file-name" style="cursor: default;">Name</span></th>
+							<th class="file-size"><span class="table-head" data-order-seq="" data-order-type="file-size" style="cursor: default;">Size</span></th>
+							<th class="file-date-modified"><span class="table-head" data-order-seq="" data-order-type="file-date-modified" style="cursor: default;">Date Modified</span></th></th>
+							<th class="center-align">Download</th>
+						</tr>
+						</thead>
+						<tbody>
+							{{if .HasParent}}
+								<tr class="parent">
+									<td class="file-name">
+										<a class="icon icon-up" href="{{.ParentPath}}"><i class="fa fa-chevron-left" aria-hidden="true"></i>&nbsp;&nbsp;..</a>
+									</td>
+									<td class="file-size"></td>
+									<td class="file-date-modified"></td>
+									<td class="file-size"></td>
+								</tr>
+							{{else}}
+							{{end}}
+							{{range .List}}
+								<tr>
+									{{if .IsFolder}}
+										<td class="file-name"><a class="icon icon-dir" href="{{.Path}}"><i class="fa fa-folder" aria-hidden="true"></i>&nbsp;&nbsp;{{.FileName}}</a></td>
+									{{else}}
+										<td class="file-name"><a class="icon icon-file"data-file-type="{{.FileType}}" data-media-type="{{.MediaType}}" data-title="{{.FileName}}" data-url="{{.Path}}" href="javascript:void(0);"><i class="fa fa-file" aria-hidden="true"></i>&nbsp;&nbsp;{{.FileName}}</a></td>
+									{{end}}
+									<td class="file-size">{{.SizeFmt}}</td>
+									<td class="file-date-modified">{{.LastOpTime}}</td>
+									{{if .IsFolder}}
+										{{if and (ne .FileId "0") (ne .FileId "-12") (ne .FileId "-14") (ne .FileId "-13") (ne .FileId "-15") (ne .FileId "-11") (ne .FileId "-16")}}
+											<td class="center-align"><a class="folderDown" data-file-id="{{.FileId}}" href="javascript:void(0);" target="_blank" ><i class="fa fa-download" aria-hidden="true"></i></a></td>
+										{{else}}
+											<td class="file-size">-</td>
+										{{end}}
+									{{else}}
+										<td class="center-align"><a href="{{.Path}}" target="_blank"><i class="fa fa-download" aria-hidden="true"></i></a></td>
+									{{end}}
+								</tr>
+							{{end}}
+						</tbody>
+					</table>
+				</div>
+				<div class="col s12 footer">
+					<div class="center-align">
+						<span>Powered by <a href="https://github.com/libsgh/PanIndex" target="_blank">PanIndex</a> | Themes by <a href="https://github.com/kasuganosoras">Akkariin</a></span>
+					</div>
+				</div>
+			</div>
+		</div>
+		{{end}}
+		<div id="example1"></div>
+	</body>
+	<script>var HerokuappUrl = {{.HerokuappUrl}}</script>
+	<script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/0.97.8/js/materialize.min.js"></script>
+	<script src="https://cdn.jsdelivr.net/npm/jquery@3.5.1/dist/jquery.min.js"></script>
+	<script src="https://cdn.bootcdn.net/ajax/libs/jquery-cookie/1.0/jquery.cookie.min.js"></script>
+	<script src="/static/js/main189.js"></script>
+</html>


### PR DESCRIPTION
肝了一下午，做了些新功能

1. 增加了 Bootstrap 和 Material Design 主题
2. 增加了自定义绑定 Host 功能（允许监听在 127.0.0.1 上，然后使用 Nginx 等软件进行 HTTPS 反代）
3. 增加绕过登录验证码功能（调用 [打码狗](http://www.damagou.top) 平台）

这个登录验证码功能是因为我在开发模板过程中由于重复调用登录接口导致账号被限制登录，需要输入验证码……所以就做了这个功能，配置文件里面的 damagou -> username 留空则不启用此功能。

主题增加了 BootStrap 和 Material Design，没有太大修改，保持精简风格（[Demo](https://staticfile-cn.zerodream.net/)），CSS 和 JS 引用了 jsDelivr 和 CloudFlare cdnjs 的服务。

自定义 Host 监听功能应该就不用介绍了……