### PR TITLE
Update main.go

### DIFF
--- a/main.go
+++ b/main.go
@@ -187,7 +187,7 @@ func refreshCookie() {
 
 func shareToDown(c *gin.Context) {
 	c.Header("Access-Control-Allow-Origin", "*")
-	c.Header("Access-Control-Allow-Methods", "*")
+	c.Header("Access-Control-Allow-Methods", "GET,HEAD,POST")
 	c.Header("Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept, Authorization")
 	c.Header("Access-Control-Expose-Headers", "Content-Length, Access-Control-Allow-Origin, Access-Control-Allow-Headers, Cache-Control, Content-Language, Content-Type")
 	c.Header("Access-Control-Allow-Credentials", "true")

--- a/main.go
+++ b/main.go
@@ -187,7 +187,7 @@ func refreshCookie() {
 
 func shareToDown(c *gin.Context) {
 	c.Header("Access-Control-Allow-Origin", "*")
-	c.Header("Access-Control-Allow-Methods", "GET")
+	c.Header("Access-Control-Allow-Methods", "*")
 	c.Header("Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept, Authorization")
 	c.Header("Access-Control-Expose-Headers", "Content-Length, Access-Control-Allow-Origin, Access-Control-Allow-Headers, Cache-Control, Content-Language, Content-Type")
 	c.Header("Access-Control-Allow-Credentials", "true")


### PR DESCRIPTION
允许所有请求方式，否则导致无法正确跨域资源共享。