### PR TITLE
fastgit加速镜像已失效，致无法下载，换为官方

### DIFF
--- a/docker/getPanIndex.sh
+++ b/docker/getPanIndex.sh
@@ -8,7 +8,7 @@ then
         | grep '"tag_name":' \
         | sed -E 's/.*"([^"]+)".*/\1/'`
 fi
-curl -sOL "https://hub.fastgit.org/libsgh/PanIndex/releases/download/${version}/PanIndex-${version}-linux-amd64.tar.gz"
+curl -sOL "https://github.com/libsgh/PanIndex/releases/download/${version}/PanIndex-${version}-linux-amd64.tar.gz"
 sha256sum "PanIndex-"${version}"-linux-amd64.tar.gz"
 tar -xvzf "PanIndex-"${version}"-linux-amd64.tar.gz"
 rm -rf README.md LICENSE


### PR DESCRIPTION
Thank author for the work.