### PR TITLE
图标字体的loli域名访问不稳定，更换为jsDelivr的CDN

### DIFF
--- a/static/css/index.css
+++ b/static/css/index.css
@@ -77,7 +77,7 @@
     font-family: 'Material Icons';
     font-style: normal;
     font-weight: 400;
-    src: url(https://gstatic.loli.net/s/materialicons/v138/flUhRq6tzZclQEJ-Vdg-IuiaDsNc.woff2) format('woff2');
+    src: url(https://gcore.jsdelivr.net/gh/marella/material-icons@v1.12.2/iconfont/material-icons.woff2) format('woff2');
 }
 
 #prev {
@@ -331,4 +331,9 @@ input {
 .mdui-theme-layout-dark {
     color: #fff;
     background-color: #424242;
+}
+.mdui-icon{
+    max-width: 24px;
+    max-height: 24px;
+    overflow: hidden;
 }


### PR DESCRIPTION
1、图标字体的loli域名访问不稳定，更换为jsDelivr的CDN
2、防止图标字体没有加载完时，页面被撑乱。